### PR TITLE
修复 JSX 中缺省 boolean 属性值的写法

### DIFF
--- a/src/core/transform/i18nPlugin.js
+++ b/src/core/transform/i18nPlugin.js
@@ -266,7 +266,7 @@ module.exports = declare((api, options) => {
       },
       JSXAttribute(path, state) {
         if (path.node.skipTransform) return;
-        const label = path.node.value.value;
+        const label = path.node.value?.value;
         if (isChinese(label)) {
           const key = generateKey(label, options.options);
           cacheKeyFunc(key, label);


### PR DESCRIPTION
JSX 中可以这样写 `<Cmp someBoolean />`，如 Antd 中的 `<Spin spinning />`，此时 _i18nPlugin.js_ L269 的 `path.node.value` 是 `null`，需要对此兼容